### PR TITLE
compositeresourcedefinition.yaml: remove region enum

### DIFF
--- a/repos/gitops-system/tools-config/crossplane-eks-composition/compositeresourcedefinition.yaml
+++ b/repos/gitops-system/tools-config/crossplane-eks-composition/compositeresourcedefinition.yaml
@@ -29,7 +29,6 @@ spec:
                   region:
                     description: Geographic location of this VPC
                     type: string       
-                    enum: ["eu-west-1", "us-east-1", "us-west-2"]   
                     
                   vpc-cidrBlock:
                     description: CIDR block for VPC


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed a constraint in the tools-config for crossplane that was unnecessarily limiting the AWS region in which the GitOps solutoin could be deployed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
