### PR TITLE
Update mgmt-cluster-eksctl.yaml: single AZ NAT

### DIFF
--- a/initial-setup/config/mgmt-cluster-eksctl.yaml
+++ b/initial-setup/config/mgmt-cluster-eksctl.yaml
@@ -12,7 +12,7 @@ iam:
 
 vpc:
   nat:
-    gateway: HighlyAvailable
+    gateway: Single
 
 managedNodeGroups:
 - name: nodegroup


### PR DESCRIPTION
Changed NAT config for mgmt cluster to single AZ, so that we only use one Elastic IP.

*Issue #, if available:*

*Description of changes:*

Changed config of mgmt cluster to use a single NAT (one AZ) so that only one Elastic IP is consumed by the mgmt cluster. This avoids the problem of running out of EIPs when running 2 workload clusters (each of which uses a minimum of 2 EIPs).

Unfortunately there does not seem to be a way to force the EKSCluster composition to use a single NAT gateway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
