### PR TITLE
Separating control and data plane upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .project
 .vscode
+wl-kube.conf

--- a/repos/gitops-system/.gitignore
+++ b/repos/gitops-system/.gitignore
@@ -1,1 +1,2 @@
 /.DS_Store
+wl-kube.conf

--- a/repos/gitops-system/clusters-config/template/def/eks-cluster.yaml
+++ b/repos/gitops-system/clusters-config/template/def/eks-cluster.yaml
@@ -6,28 +6,28 @@ metadata:
 spec:
   parameters:
     region: AWS_REGION
-    vpc-name: "cluster-name-eks-vpc"
-    vpc-cidrBlock: "10.20.0.0/16"
+    vpc-name: 'cluster-name-eks-vpc'
+    vpc-cidrBlock: '10.20.0.0/16'
 
-    subnet1-public-name: "public-worker-1"
-    subnet1-public-cidrBlock: "10.20.1.0/24"
-    subnet1-public-availabilityZone: "AWS_REGIONa"
-    
-    subnet2-public-name: "public-worker-2"
-    subnet2-public-cidrBlock: "10.20.2.0/24"
-    subnet2-public-availabilityZone: "AWS_REGIONb"    
+    subnet1-public-name: 'public-worker-1'
+    subnet1-public-cidrBlock: '10.20.1.0/24'
+    subnet1-public-availabilityZone: 'AWS_REGIONa'
 
-    subnet1-private-name: "private-worker-1"
-    subnet1-private-cidrBlock: "10.20.11.0/24"
-    subnet1-private-availabilityZone: "AWS_REGIONa"
-    
-    subnet2-private-name: "private-worker-2"
-    subnet2-private-cidrBlock: "10.20.12.0/24"
-    subnet2-private-availabilityZone: "AWS_REGIONb"     
+    subnet2-public-name: 'public-worker-2'
+    subnet2-public-cidrBlock: '10.20.2.0/24'
+    subnet2-public-availabilityZone: 'AWS_REGIONb'
 
+    subnet1-private-name: 'private-worker-1'
+    subnet1-private-cidrBlock: '10.20.11.0/24'
+    subnet1-private-availabilityZone: 'AWS_REGIONa'
 
-    k8s-version: "1.21"
-    workload-type: "non-gpu"
+    subnet2-private-name: 'private-worker-2'
+    subnet2-private-cidrBlock: '10.20.12.0/24'
+    subnet2-private-availabilityZone: 'AWS_REGIONb'
+
+    eks-k8s-version: '1.21'
+    mng-k8s-version: '1.21'
+    workload-type: 'non-gpu'
     workers-size: 2
 
   compositionRef:

--- a/repos/gitops-system/tools-config/crossplane-eks-composition/compositeresourcedefinition.yaml
+++ b/repos/gitops-system/tools-config/crossplane-eks-composition/compositeresourcedefinition.yaml
@@ -13,116 +13,121 @@ spec:
     - apiserver-endpoint
     - value
   versions:
-  - name: v1beta1
-    served: true
-    referenceable: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              parameters:
-                type: object
-                properties:
-                  region:
-                    description: Geographic location of this VPC
-                    type: string       
-                    
-                  vpc-cidrBlock:
-                    description: CIDR block for VPC
-                    type: string   
-                  vpc-name:
-                    description: Name for VPC
-                    type: string       
+    - name: v1beta1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    region:
+                      description: Geographic location of this VPC
+                      type: string
 
-                  subnet1-public-name:
-                    description: Name for public subnet 1
-                    type: string  
-                  subnet1-public-cidrBlock:
-                    description: CIDR block for public subnet 1
-                    type: string
-                  subnet1-public-availabilityZone:
-                    description: AZ for public subnet 1
-                    type: string                      
+                    vpc-cidrBlock:
+                      description: CIDR block for VPC
+                      type: string
+                    vpc-name:
+                      description: Name for VPC
+                      type: string
 
-                  subnet2-public-name:
-                    description: Name for public subnet 2
-                    type: string  
-                  subnet2-public-cidrBlock:
-                    description: CIDR block for public subnet 2
-                    type: string  
-                  subnet2-public-availabilityZone:
-                    description: AZ for public subnet 2
-                    type: string   
+                    subnet1-public-name:
+                      description: Name for public subnet 1
+                      type: string
+                    subnet1-public-cidrBlock:
+                      description: CIDR block for public subnet 1
+                      type: string
+                    subnet1-public-availabilityZone:
+                      description: AZ for public subnet 1
+                      type: string
 
-                  subnet1-private-name:
-                    description: Name for private subnet 1
-                    type: string  
-                  subnet1-private-cidrBlock:
-                    description: CIDR block for private subnet 1
-                    type: string
-                  subnet1-private-availabilityZone:
-                    description: AZ for private subnet 1
-                    type: string                      
+                    subnet2-public-name:
+                      description: Name for public subnet 2
+                      type: string
+                    subnet2-public-cidrBlock:
+                      description: CIDR block for public subnet 2
+                      type: string
+                    subnet2-public-availabilityZone:
+                      description: AZ for public subnet 2
+                      type: string
 
-                  subnet2-private-name:
-                    description: Name for private subnet 2
-                    type: string  
-                  subnet2-private-cidrBlock:
-                    description: CIDR block for private subnet 2
-                    type: string  
-                  subnet2-private-availabilityZone:
-                    description: AZ for private subnet 2
-                    type: string  
+                    subnet1-private-name:
+                      description: Name for private subnet 1
+                      type: string
+                    subnet1-private-cidrBlock:
+                      description: CIDR block for private subnet 1
+                      type: string
+                    subnet1-private-availabilityZone:
+                      description: AZ for private subnet 1
+                      type: string
 
-                  k8s-version:
-                    description: Kubernetes version
-                    type: string
-                    enum: ["1.20", "1.21", "1.22"]    
-                  workers-size:
-                    description: Desired number of worker nodes in the cluster
-                    type: integer
-                  workload-type:
-                    description: Type of workloads to be run on this cluster (GPU or non-GPU)"
-                    type: string       
-                    enum: ["gpu", "non-gpu"]                       
-                    
-                required:
-                  - region
-                  - vpc-name
-                  - vpc-cidrBlock
-                  - subnet1-public-name
-                  - subnet1-public-cidrBlock
-                  - subnet1-public-availabilityZone
-                  - subnet2-public-name
-                  - subnet2-public-cidrBlock
-                  - subnet2-public-availabilityZone
-                  - subnet1-private-name
-                  - subnet1-private-cidrBlock
-                  - subnet1-private-availabilityZone
-                  - subnet2-private-name
-                  - subnet2-private-cidrBlock
-                  - subnet2-private-availabilityZone    
-                  - k8s-version
-                  - workers-size
-                  - workload-type              
-            required:
-              - parameters
-          status:
-            description: A Status represents the observed state
-            properties:
-              account_id:
-                description: Account ID
-                type: string
-              eks_cluster_arn:
-                description: ARN of the EKS cluster
-                type: string
-              eks_cluster_oidc_issuer_url:
-                description: OIDC issuer url for the EKS cluster
-                type: string
-              eks_cluster_oidc_issuer:
-                description: OIDC issuer for the EKS cluster
-                type: string
-            type: object
+                    subnet2-private-name:
+                      description: Name for private subnet 2
+                      type: string
+                    subnet2-private-cidrBlock:
+                      description: CIDR block for private subnet 2
+                      type: string
+                    subnet2-private-availabilityZone:
+                      description: AZ for private subnet 2
+                      type: string
+
+                    eks-k8s-version:
+                      description: Kubernetes version
+                      type: string
+                      enum: ['1.20', '1.21', '1.22']
+                    mng-k8s-version:
+                      description: Kubernetes version
+                      type: string
+                      enum: ['1.20', '1.21', '1.22']
+                    workers-size:
+                      description: Desired number of worker nodes in the cluster
+                      type: integer
+                    workload-type:
+                      description: Type of workloads to be run on this cluster (GPU or non-GPU)"
+                      type: string
+                      enum: ['gpu', 'non-gpu']
+
+                  required:
+                    - region
+                    - vpc-name
+                    - vpc-cidrBlock
+                    - subnet1-public-name
+                    - subnet1-public-cidrBlock
+                    - subnet1-public-availabilityZone
+                    - subnet2-public-name
+                    - subnet2-public-cidrBlock
+                    - subnet2-public-availabilityZone
+                    - subnet1-private-name
+                    - subnet1-private-cidrBlock
+                    - subnet1-private-availabilityZone
+                    - subnet2-private-name
+                    - subnet2-private-cidrBlock
+                    - subnet2-private-availabilityZone
+                    - eks-k8s-version
+                    - mng-k8s-version
+                    - workers-size
+                    - workload-type
+              required:
+                - parameters
+            status:
+              description: A Status represents the observed state
+              properties:
+                account_id:
+                  description: Account ID
+                  type: string
+                eks_cluster_arn:
+                  description: ARN of the EKS cluster
+                  type: string
+                eks_cluster_oidc_issuer_url:
+                  description: OIDC issuer url for the EKS cluster
+                  type: string
+                eks_cluster_oidc_issuer:
+                  description: OIDC issuer for the EKS cluster
+                  type: string
+              type: object

--- a/repos/gitops-system/tools-config/crossplane-eks-composition/composition.yaml
+++ b/repos/gitops-system/tools-config/crossplane-eks-composition/composition.yaml
@@ -16,8 +16,8 @@ spec:
   patchSets:
     - name: common-parameters
       patches:
-        - fromFieldPath: "spec.parameters.region"
-          toFieldPath: "spec.forProvider.region"
+        - fromFieldPath: 'spec.parameters.region'
+          toFieldPath: 'spec.forProvider.region'
     - name: cluster-info-mappings
       patches:
         - fromFieldPath: status.account_id
@@ -46,9 +46,9 @@ spec:
             enableDnsHostNames: true
             tags:
               - key: Name
-      patches:    
+      patches:
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.vpc-cidrBlock
           toFieldPath: spec.forProvider.cidrBlock
         - fromFieldPath: spec.parameters.vpc-name
@@ -69,17 +69,17 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             tags:
-              - key: Name              
-      patches:    
+              - key: Name
+      patches:
         - type: PatchSet
-          patchSetName: common-parameters 
+          patchSetName: common-parameters
         - type: CombineFromComposite
           combine:
             variables:
               - fromFieldPath: spec.parameters.vpc-name
             strategy: string
             string:
-              fmt: "%s-igw"
+              fmt: '%s-igw'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
@@ -100,8 +100,8 @@ spec:
             tags:
               - key: Name
               - key: kubernetes.io/role/elb
-                value: "1"
-      patches:             
+                value: '1'
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
@@ -109,18 +109,18 @@ spec:
               - fromFieldPath: spec.parameters.subnet1-public-name
             strategy: string
             string:
-              fmt: "%s-%s"
+              fmt: '%s-%s'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet1-public-cidrBlock
           toFieldPath: spec.forProvider.cidrBlock
         - fromFieldPath: spec.parameters.subnet1-public-availabilityZone
           toFieldPath: spec.forProvider.availabilityZone
         - fromFieldPath: spec.parameters.subnet1-public-availabilityZone
-          toFieldPath: metadata.labels.zone     
+          toFieldPath: metadata.labels.zone
 
     - name: subnet-public-2
       base:
@@ -129,7 +129,7 @@ spec:
         metadata:
           labels:
             type: subnet
-            visibility: public          
+            visibility: public
         spec:
           forProvider:
             mapPublicIpOnLaunch: true
@@ -138,8 +138,8 @@ spec:
             tags:
               - key: Name
               - key: kubernetes.io/role/elb
-                value: "1"
-      patches:             
+                value: '1'
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
@@ -147,18 +147,18 @@ spec:
               - fromFieldPath: spec.parameters.subnet2-public-name
             strategy: string
             string:
-              fmt: "%s-%s"
+              fmt: '%s-%s'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet2-public-cidrBlock
           toFieldPath: spec.forProvider.cidrBlock
         - fromFieldPath: spec.parameters.subnet2-public-availabilityZone
           toFieldPath: spec.forProvider.availabilityZone
         - fromFieldPath: spec.parameters.subnet2-public-availabilityZone
-          toFieldPath: metadata.labels.zone  
+          toFieldPath: metadata.labels.zone
 
     - name: subnet-private-1
       base:
@@ -167,7 +167,7 @@ spec:
         metadata:
           labels:
             type: subnet
-            visibility: private          
+            visibility: private
         spec:
           forProvider:
             mapPublicIpOnLaunch: false
@@ -176,8 +176,8 @@ spec:
             tags:
               - key: Name
               - key: kubernetes.io/role/internal-elb
-                value: "1"
-      patches:             
+                value: '1'
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
@@ -185,19 +185,19 @@ spec:
               - fromFieldPath: spec.parameters.subnet1-private-name
             strategy: string
             string:
-              fmt: "%s-%s"
+              fmt: '%s-%s'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet1-private-cidrBlock
           toFieldPath: spec.forProvider.cidrBlock
         - fromFieldPath: spec.parameters.subnet1-private-availabilityZone
           toFieldPath: spec.forProvider.availabilityZone
         - fromFieldPath: spec.parameters.subnet1-private-availabilityZone
-          toFieldPath: metadata.labels.zone                   
-          
+          toFieldPath: metadata.labels.zone
+
     - name: subnet-private-2
       base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
@@ -205,7 +205,7 @@ spec:
         metadata:
           labels:
             type: subnet
-            visibility: private           
+            visibility: private
         spec:
           forProvider:
             mapPublicIpOnLaunch: false
@@ -214,8 +214,8 @@ spec:
             tags:
               - key: Name
               - key: kubernetes.io/role/internal-elb
-                value: "1"
-      patches:             
+                value: '1'
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
@@ -223,18 +223,18 @@ spec:
               - fromFieldPath: spec.parameters.subnet2-private-name
             strategy: string
             string:
-              fmt: "%s-%s"
+              fmt: '%s-%s'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet2-private-cidrBlock
           toFieldPath: spec.forProvider.cidrBlock
         - fromFieldPath: spec.parameters.subnet2-private-availabilityZone
           toFieldPath: spec.forProvider.availabilityZone
         - fromFieldPath: spec.parameters.subnet2-private-availabilityZone
-          toFieldPath: metadata.labels.zone             
+          toFieldPath: metadata.labels.zone
 
     - name: elastic-ip-1
       base:
@@ -246,7 +246,7 @@ spec:
         spec:
           forProvider:
             domain: vpc
-      patches:    
+      patches:
         - type: PatchSet
           patchSetName: common-parameters
         - fromFieldPath: spec.parameters.vpc-name
@@ -258,13 +258,13 @@ spec:
         kind: Address
         metadata:
           labels:
-            type: eip-2        
+            type: eip-2
         spec:
           forProvider:
             domain: vpc
-      patches:    
+      patches:
         - type: PatchSet
-          patchSetName: common-parameters     
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.vpc-name
           toFieldPath: metadata.labels.vpc-name
 
@@ -287,27 +287,26 @@ spec:
               matchControllerRef: true
               matchLabels:
                 type: subnet
-                visibility: public                   
+                visibility: public
             tags:
-              - key: Name                    
-      patches:             
+              - key: Name
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
               - fromFieldPath: spec.parameters.vpc-name
             strategy: string
             string:
-              fmt: "%s-nat-gateway-1"
+              fmt: '%s-nat-gateway-1'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet1-public-availabilityZone
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels.zone
         - fromFieldPath: spec.parameters.vpc-name
           toFieldPath: spec.forProvider.allocationIdSelector.matchLabels.vpc-name
-
 
     - name: natgateway-2
       base:
@@ -321,31 +320,31 @@ spec:
             allocationIdSelector:
               matchControllerRef: true
               matchLabels:
-                type: eip-2 
+                type: eip-2
             vpcIdSelector:
-              matchControllerRef: true   
+              matchControllerRef: true
             subnetIdSelector:
               matchControllerRef: true
               matchLabels:
                 type: subnet
-                visibility: public                   
+                visibility: public
             tags:
-              - key: Name                    
-      patches:             
+              - key: Name
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
               - fromFieldPath: spec.parameters.vpc-name
             strategy: string
             string:
-              fmt: "%s-nat-gateway-2"
+              fmt: '%s-nat-gateway-2'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters      
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet2-public-availabilityZone
-          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels.zone       
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels.zone
         - fromFieldPath: spec.parameters.vpc-name
           toFieldPath: spec.forProvider.allocationIdSelector.matchLabels.vpc-name
 
@@ -368,31 +367,31 @@ spec:
                   matchControllerRef: true
                   matchLabels:
                     type: subnet
-                    visibility: public                   
+                    visibility: public
               - subnetIdSelector:
                   matchControllerRef: true
                   matchLabels:
                     type: subnet
-                    visibility: public                   
+                    visibility: public
             tags:
               - key: Name
-      patches:    
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
               - fromFieldPath: spec.parameters.vpc-name
             strategy: string
             string:
-              fmt: "%s-public-route-table"
+              fmt: '%s-public-route-table'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters 
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet1-public-availabilityZone
-          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone 
+          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone
         - fromFieldPath: spec.parameters.subnet2-public-availabilityZone
-          toFieldPath: spec.forProvider.associations[1].subnetIdSelector.matchLabels.zone 
+          toFieldPath: spec.forProvider.associations[1].subnetIdSelector.matchLabels.zone
 
     - name: routetable-private-1
       base:
@@ -413,24 +412,24 @@ spec:
                   matchControllerRef: true
                   matchLabels:
                     type: subnet
-                    visibility: private                   
+                    visibility: private
             tags:
               - key: Name
-      patches:    
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
               - fromFieldPath: spec.parameters.vpc-name
             strategy: string
             string:
-              fmt: "%s-private-route-table-1"
+              fmt: '%s-private-route-table-1'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters           
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet1-public-availabilityZone
-          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone 
+          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone
 
     - name: routetable-private-2
       base:
@@ -451,24 +450,24 @@ spec:
                   matchControllerRef: true
                   matchLabels:
                     type: subnet
-                    visibility: private                   
+                    visibility: private
             tags:
               - key: Name
-      patches:    
+      patches:
         - type: CombineFromComposite
           combine:
             variables:
               - fromFieldPath: spec.parameters.vpc-name
             strategy: string
             string:
-              fmt: "%s-private-route-table-2"
+              fmt: '%s-private-route-table-2'
           toFieldPath: spec.forProvider.tags[0].value
           policy:
             fromFieldPath: Required
         - type: PatchSet
-          patchSetName: common-parameters   
+          patchSetName: common-parameters
         - fromFieldPath: spec.parameters.subnet2-public-availabilityZone
-          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone 
+          toFieldPath: spec.forProvider.associations[0].subnetIdSelector.matchLabels.zone
 
     - name: eks-cluster
       base:
@@ -488,17 +487,17 @@ spec:
                   type: subnet
           writeConnectionSecretToRef:
             namespace: crossplane-system
-      patches:    
+      patches:
         - type: PatchSet
-          patchSetName: common-parameters      
-        - fromFieldPath: "spec.parameters.k8s-version"
-          toFieldPath: "spec.forProvider.version"            
-        - fromFieldPath: "metadata.uid"
-          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          patchSetName: common-parameters
+        - fromFieldPath: 'spec.parameters.eks-k8s-version'
+          toFieldPath: 'spec.forProvider.version'
+        - fromFieldPath: 'metadata.uid'
+          toFieldPath: 'spec.writeConnectionSecretToRef.name'
           transforms:
             - type: string
               string:
-                fmt: "%s-ekscluster-connection"
+                fmt: '%s-ekscluster-connection'
         - type: ToCompositeFieldPath
           fromFieldPath: status.atProvider.arn
           toFieldPath: status.eks_cluster_arn
@@ -530,34 +529,34 @@ spec:
             nodeRoleSelector:
               matchLabels:
                 type: eks-nodegroup-role
-            instanceTypes: 
-              - m5.large            
+            instanceTypes:
+              - m5.large
             scalingConfig:
               minSize: 1
             subnetSelector:
               matchControllerRef: true
               matchLabels:
                 type: subnet
-                visibility: private                 
+                visibility: private
             clusterNameSelector:
               matchControllerRef: true
-      patches:    
+      patches:
         - type: PatchSet
-          patchSetName: common-parameters      
-        - fromFieldPath: "spec.parameters.k8s-version"
-          toFieldPath: "spec.forProvider.version"
-        - fromFieldPath: "spec.parameters.workers-size"
-          toFieldPath: "spec.forProvider.scalingConfig.desiredSize"    
-        - fromFieldPath: "spec.parameters.workers-size"
-          toFieldPath: "spec.forProvider.scalingConfig.maxSize"      
-        - fromFieldPath: "spec.parameters.workload-type"
-          toFieldPath: "spec.forProvider.amiType"            
+          patchSetName: common-parameters
+        - fromFieldPath: 'spec.parameters.mng-k8s-version'
+          toFieldPath: 'spec.forProvider.version'
+        - fromFieldPath: 'spec.parameters.workers-size'
+          toFieldPath: 'spec.forProvider.scalingConfig.desiredSize'
+        - fromFieldPath: 'spec.parameters.workers-size'
+          toFieldPath: 'spec.forProvider.scalingConfig.maxSize'
+        - fromFieldPath: 'spec.parameters.workload-type'
+          toFieldPath: 'spec.forProvider.amiType'
           transforms:
-          - type: map
-            map:
-              gpu: AL2_x86_64_GPU
-              non-gpu: AL2_x86_64        
-    
+            - type: map
+              map:
+                gpu: AL2_x86_64_GPU
+                non-gpu: AL2_x86_64
+
     - name: cluster-oidc-idp
       base:
         apiVersion: iam.aws.crossplane.io/v1beta1
@@ -569,19 +568,19 @@ spec:
             clientIDList:
               - sts.amazonaws.com
             thumbprintList:
-              - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+              - '9e99a48a9960b14926bb7f3b02e22da2b0ab7280'
       patches:
         - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
             - type: string
               string:
-                fmt: "cluster-oidc-idp-%s"
+                fmt: 'cluster-oidc-idp-%s'
         - fromFieldPath: status.eks_cluster_oidc_issuer_url
           toFieldPath: spec.forProvider.url
           policy:
             fromFieldPath: Required
-    
+
     - name: configmap-cluster-info-workload-cluster
       base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -599,10 +598,10 @@ spec:
                 labels:
                   createdBy: crossplane
               data:
-                ACCOUNT_ID: ""
-                AWS_REGION: ""
-                CLUSTER_ARN: ""
-                OIDC_PROVIDER: ""
+                ACCOUNT_ID: ''
+                AWS_REGION: ''
+                CLUSTER_ARN: ''
+                OIDC_PROVIDER: ''
           providerConfigRef:
             name: k8s-providerconfig
       patches:
@@ -611,16 +610,16 @@ spec:
           transforms:
             - type: string
               string:
-                fmt: "configmap-cluster-info-%s"
+                fmt: 'configmap-cluster-info-%s'
         - fromFieldPath: metadata.name
           toFieldPath: spec.forProvider.manifest.metadata.name
           transforms:
             - type: string
               string:
-                fmt: "cluster-info-%s"
+                fmt: 'cluster-info-%s'
         - type: PatchSet
           patchSetName: cluster-info-mappings
-    
+
     # Creating cluster-info ConfigMap for the workload cluster here
     # because of a bug in serverside patch apply
     # https://github.com/kubernetes/kubernetes/issues/94275
@@ -646,15 +645,15 @@ spec:
           transforms:
             - type: string
               string:
-                fmt: "remote-k8s-providerconfig-%s"
+                fmt: 'remote-k8s-providerconfig-%s'
         # This ProviderConfig uses the above EKS cluster's connection secret as
         # its credentials secret.
-        - fromFieldPath: "metadata.uid"
+        - fromFieldPath: 'metadata.uid'
           toFieldPath: spec.credentials.secretRef.name
           transforms:
             - type: string
               string:
-                fmt: "%s-ekscluster-connection"
+                fmt: '%s-ekscluster-connection'
       readinessChecks:
         - type: None
 
@@ -681,13 +680,13 @@ spec:
           transforms:
             - type: string
               string:
-                fmt: "remote-k8s-providerconfig-%s"
+                fmt: 'remote-k8s-providerconfig-%s'
         - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
             - type: string
               string:
-                fmt: "remote-namespace-flux-system-%s"
+                fmt: 'remote-namespace-flux-system-%s'
 
     - name: remote-configmap-cluster-info-workload-cluster
       base:
@@ -706,10 +705,10 @@ spec:
                 labels:
                   createdBy: crossplane
               data:
-                ACCOUNT_ID: ""
-                AWS_REGION: ""
-                CLUSTER_ARN: ""
-                OIDC_PROVIDER: ""
+                ACCOUNT_ID: ''
+                AWS_REGION: ''
+                CLUSTER_ARN: ''
+                OIDC_PROVIDER: ''
           providerConfigRef:
             name: remote-k8s-providerconfig-workload-cluster
       patches:
@@ -718,12 +717,12 @@ spec:
           transforms:
             - type: string
               string:
-                fmt: "remote-k8s-providerconfig-%s"
+                fmt: 'remote-k8s-providerconfig-%s'
         - fromFieldPath: metadata.name
           toFieldPath: metadata.name
           transforms:
             - type: string
               string:
-                fmt: "remote-configmap-cluster-info-%s"
+                fmt: 'remote-configmap-cluster-info-%s'
         - type: PatchSet
           patchSetName: cluster-info-mappings

--- a/scenarios.md
+++ b/scenarios.md
@@ -1,6 +1,7 @@
 # Scenarios
 
 This document walks you through steps for a number of scenarios covering:
+
 - Adding a workload cluster
 - Adding an application to a workload cluster (including associated AWS resources)
 - Connecting to a workload cluster to check reconciliation status
@@ -10,18 +11,20 @@ This document walks you through steps for a number of scenarios covering:
 - Removing a workload cluster
 
 For illustration purposes, these scenarios are based on the example of a product catalog application developed by the commercial department of an organisation.
+
 - The department
-runs two clusters `commercial-staging` and `commercial-prod`.
+  runs two clusters `commercial-staging` and `commercial-prod`.
 - The product catalog application comprises two microservices which are owned by different teams.
   - API server: this provides the backend, and makes use of an AWS DynamoDB table to store its state.
   - Front end server: provides a web front end service that can be accessed via a browser.
 
 Pre-prepared manifest files for the application workloads are included in the
 `repos/apps-manifests` directory as follows:
+
 - `reops/apps-manifests/product-catalog-api-manifests`: contains manifests for two distinct versions of the API server, labelled `V1` and `V2`.
 - `reops/apps-manifests/product-catalog-fe-manifests`: contains manifests for the front end
-server.
-You can see that both of these include overlays for both the `commercial-staging` and `commercial-prod` clusters.
+  server.
+  You can see that both of these include overlays for both the `commercial-staging` and `commercial-prod` clusters.
 
 ## Provision and bootstrap a new workload cluster
 
@@ -30,12 +33,14 @@ In this section you will create a new workload cluster called `commercial-stagin
 changes so that flux can pick them up and act on them.
 
 You can make the required changes quickly using the script `add-cluster.sh`:
+
 ```
 cd ~/environment
 multi-cluster-gitops/bin/add-cluster.sh ./gitops-system commercial-staging
 ```
 
 Once done, commit and push the changes as follows:
+
 ```
 cd gitops-system
 git add .
@@ -44,9 +49,11 @@ git push
 ```
 
 Use
+
 ```
 kubectl get kustomization -n flux-system
 ```
+
 to monitor the creation of resources for the new cluster.
 
 You can repeat the same process to create the `commercial-prod` cluster.
@@ -56,36 +63,28 @@ You can repeat the same process to create the `commercial-prod` cluster.
 The `add-cluster.sh` script performs the following steps. You can choose to execute these steps instead of running the script. Please ensure your working directory is set to `~/environment` before executing.
 
 1. **Instantiate the `cluster-configs` template:** This creates a folder for the new `commercial-staging` cluster under `cluster-configs`, and copies the template.
-It then replaces all occurances of `cluster-name` in the template with `commercial-staging`.
-    ```
-    mkdir -p gitops_system/clusters-config/commercial-staging
-    cp -R gitops_system/clusters-config/template/* gitops_system/clusters-config/commercial-staging
-    grep -RiIl 'cluster-name' gitops_system/clusters-config/commercial-staging| xargs sed -i "s/cluster-name/commercial-staging/g"
-    ```
+   It then replaces all occurances of `cluster-name` in the template with `commercial-staging`.
+   `mkdir -p gitops_system/clusters-config/commercial-staging cp -R gitops_system/clusters-config/template/* gitops_system/clusters-config/commercial-staging grep -RiIl 'cluster-name' gitops_system/clusters-config/commercial-staging| xargs sed -i "s/cluster-name/commercial-staging/g"`
 
 2. **Instantiate the `cluster` template:** This create a folder for the `commcercial-staging` cluster
-under `clusters`, and copies the template. It then replaces all occurances of `cluster-name` in the template with `commercial-staging`.
-    ```
-    mkdir -p gitops_system/clusters/commercial-staging
-    cp -R gitops_system/clusters/template/* gitops_system/clusters/commercial-staging
-    grep -RiIl 'cluster-name' gitops_system/clusters/commercial-staging | xargs sed -i "s/cluster-name/commercial-staging/g"
-    ```
+   under `clusters`, and copies the template. It then replaces all occurances of `cluster-name` in the template with `commercial-staging`.
+   `mkdir -p gitops_system/clusters/commercial-staging cp -R gitops_system/clusters/template/* gitops_system/clusters/commercial-staging grep -RiIl 'cluster-name' gitops_system/clusters/commercial-staging | xargs sed -i "s/cluster-name/commercial-staging/g"`
 
 3. **Instantiate the `workloads` template.** This creates a folder for the
- `commcercial-staging` cluster under `workloads` and copies the template. It then
- replaces all occurences of `cluster-name` in the template with `commercial-staging`.
-    ```
-    mkdir -p gitops_system/workloads/commercial-staging
-    cp -R gitops_system/workloads/template/* gitops_system/workloads/commercial-staging
-    grep -RiIl 'cluster-name'  gitops_system/workloads/commercial-staging | xargs sed -i "s/cluster-name/commercial-staging/g"
-    ```
+   `commcercial-staging` cluster under `workloads` and copies the template. It then
+   replaces all occurences of `cluster-name` in the template with `commercial-staging`.
 
-4.  **Add `commercial-staging` to `clusters-config/kustomization.yaml`.**
-    This forces Flux to pick up the new cluster config.
-    ```
-    yq -i e ".resources += [\"commercial-staging\"]" gitops_system/clusters-config/kustomization.yaml
-    ```
+   ```
+   mkdir -p gitops_system/workloads/commercial-staging
+   cp -R gitops_system/workloads/template/* gitops_system/workloads/commercial-staging
+   grep -RiIl 'cluster-name'  gitops_system/workloads/commercial-staging | xargs sed -i "s/cluster-name/commercial-staging/g"
+   ```
 
+4. **Add `commercial-staging` to `clusters-config/kustomization.yaml`.**
+   This forces Flux to pick up the new cluster config.
+   ```
+   yq -i e ".resources += [\"commercial-staging\"]" gitops_system/clusters-config/kustomization.yaml
+   ```
 
 ## Add an application to a cluster
 
@@ -95,6 +94,7 @@ create manifest files for the new application in `gitops-workloads/commercial-st
 changes so that flux can pick them up and act on them.
 
 First, prepare a repo for `product-catalog-api-manifests` as follows:
+
 ```
 cd ~/environment
 gh repo create --private --clone product-catalog-api-manifests
@@ -107,12 +107,14 @@ git push --set-upstream origin main
 ```
 
 Next, tag the current commit as version 1.0 and push the tag:
+
 ```
 git tag -a v1.0 -m "Version 1.0"
 git push origin v1.0
 ```
 
-You can make the required changes in `gitops-workloads`  using the script `add-cluster-app.sh`:
+You can make the required changes in `gitops-workloads` using the script `add-cluster-app.sh`:
+
 ```
 cd ~/environment
 multi-cluster-gitops/bin/add-cluster-app.sh \
@@ -125,21 +127,25 @@ multi-cluster-gitops/bin/add-cluster-app.sh \
 ```
 
 Once done, commit and push the changes as follows:
+
 ```
 cd gitops-workloads
 git add .
 git commit -m "Add product-catalog-api to commercial-staging"
 ```
+
 If this is the first commit on `gitops-workloads`, you need to rename the branch to `main`, and push the changes as follows:
+
 ```
 git branch -M main
 git push --set-upstream origin main
 ```
+
 Otherwise, you just push the changes as follows:
+
 ```
 git push
 ```
-
 
 To view the reconciliation of resources in the workload cluster, and verify that application
 resources have been created, see the section [Connect to a workload cluster](#connect-to-a-workload-cluster). You can also see the resources created in the workload cluster through the EKS console. In this case, you have to access the EKS console using the IAM entity whose ARN is set in `EKS_CONSOLE_IAM_ENTITY_ARN` environment variable during the initial setup.
@@ -157,12 +163,14 @@ include overlays for each of `commercial-staging` and `commercial-prod`.
 The `add-cluster-app.sh` script performs the following steps. You can choose to execute these steps instead of running the script. Please ensure your working directory is set to `~/environment` before executing.
 
 1. **Ensure a directory for the application exists under `gitops-workloads/commercial-staging`:** create a directory if it does not yet exist (i.e. this is the first app in this cluster).
+
 ```
 mkdir -p gitops-workloads/commercial-staging/product-catalog-api
 ```
 
 2. **Ensure a `kustomization.yaml` file exists:** check if the file exists, and if not then
-create one by copying the template (only happens for the first app that is added to the cluster).
+   create one by copying the template (only happens for the first app that is added to the cluster).
+
 ```
 if [[ ! -f gitops-workloads/commercial-staging/kustomization.yaml ]]
 then
@@ -171,7 +179,8 @@ fi
 ```
 
 3. **Instantiate the workloads application template:** this copies the application template
-from `gitops-workloads/template/app-template` to `gitops-workloads/commercial-staging/product-catalog-api`, and then updates the cluster name and app name to the correct values.
+   from `gitops-workloads/template/app-template` to `gitops-workloads/commercial-staging/product-catalog-api`, and then updates the cluster name and app name to the correct values.
+
 ```
 cp -R gitops-workloads/template/app-template/* gitops-workloads/commercial-staging/product-catalog-api
 grep -RiIl 'cluster-name' gitops-workloads/commercial-staging/product-catalog-api | xargs sed -i "s/cluster-name/commercial-staging/g"
@@ -180,11 +189,11 @@ grep -RiIl 'release-tag' gitops-workloads/commercial-staging/product-catalog-api
 ```
 
 4. **Prepare the sealed secret for the application:** this prepares a sealed secret for the
-application, which contains the Git credentials needed to access the repo. A
-temporary file is used to store a copy of the Git credentials template (which is
-a K8s `Secret`). This file is updated to use the correct name, public/private key pair, and
-known hosts. `kubeseal` is then used to create a sealed secret, using a supplied `.pem` file
-containing a key to encrypt the sealed secret which is stored in `gitops-workloads/commercial-staging/product-catalog-api/git-secret.yaml`.
+   application, which contains the Git credentials needed to access the repo. A
+   temporary file is used to store a copy of the Git credentials template (which is
+   a K8s `Secret`). This file is updated to use the correct name, public/private key pair, and
+   known hosts. `kubeseal` is then used to create a sealed secret, using a supplied `.pem` file
+   containing a key to encrypt the sealed secret which is stored in `gitops-workloads/commercial-staging/product-catalog-api/git-secret.yaml`.
 
 ```
 tmp_git_creds=$(mktemp /tmp/git-creds.yaml.XXXXXXXXX)
@@ -208,7 +217,7 @@ yq -i e ".resources += [\"product-catalog-api\"]" gitops-workloads/commercial-st
 To connect to `<cluster-name>` workload cluster using `kubeconfig` stored as a `Secret`
 
 1. In a terminal window that is currently configured for the management cluster, obtain a
-config file for the workload cluster using:
+   config file for the workload cluster using:
 
 ```bash
 unset KUBECONFIG
@@ -217,6 +226,7 @@ export KUBECONFIG=wl-kube.conf
 
 kubectl config current-context
 ```
+
 (Replace `<cluster-name>` with the cluster name).
 
 **Note:** A convenience script `eks-multi-cluster-gitops/bin/connect-to-cluster.sh` is provided to quickly connect to a cluster.
@@ -226,15 +236,13 @@ In a bash terminal source the script to generate the kubeconfig file and export 
 source eks-multi-cluster-gitops/bin/connect-to-cluster.sh <cluster-name>
 ```
 
-
-
 2. To monitor the bootstrapping of the workload clusters (and subseuently for the
-  deployment of the applications into it), list the `Kustomization` resources
-  using the following command:
+   deployment of the applications into it), list the `Kustomization` resources
+   using the following command:
 
-  ```bash
-  kubectl get kustomization -n flux-system
-  ```
+```bash
+kubectl get kustomization -n flux-system
+```
 
 ## Upgrade an existing application
 
@@ -244,6 +252,7 @@ the cluster `commercial-staging`. To achieve this, you need to update the releas
 The new version of the application makes use of a DynamoDB table which is created by Crossplane. So, the service account used by the application pods needs to be attached to an IAM role with the required permissions.
 
 First, the policy document specified in the `Policy` CRD that exists in `gitops-workloads/commercial-staging/product-catalog-api/app-iam.yaml` has to be changed as follows:
+
 ```
         {
           "Version": "2012-10-17",
@@ -259,6 +268,7 @@ First, the policy document specified in the `Policy` CRD that exists in `gitops-
 ```
 
 Next, commit this change:
+
 ```
 cd ~/environment/gitops-workloads
 git add .
@@ -267,6 +277,7 @@ git push
 ```
 
 Next, update the repo for `product-catalog-api` to the new version (v2):
+
 ```
 cd ~/environment
 cp -r multi-cluster-gitops/repos/apps-manifests/product-catalog-api-manifests/v2/* product-catalog-api-manifests/
@@ -277,6 +288,7 @@ git push origin main
 ```
 
 Next, tag the current commit as version 2.0 and push the tag:
+
 ```
 git tag -a v2.0 -m "Version 2.0"
 git push origin v2.0
@@ -284,12 +296,14 @@ git push origin v2.0
 
 Update the release tag in `gitops-workloads/commercial-staging/product-catalog-api`. You
 can do this using the `update-cluster-app.sh` script as follows:
+
 ```
 cd ~/environment
 multi-cluster-gitops/bin/update-cluster-app.sh ./gitops-workloads commercial-staging product-catalog-api v2.0
 ```
 
 Finally, commit this change:
+
 ```
 cd gitops-workloads
 git add .
@@ -299,22 +313,24 @@ git push
 
 Monitor the reconciliation in the cluster. You can verify that the application deployment
 has been updated by checking the deployment history:
+
 ```
 kubectl rollout history deployment/product-catalog-api-staging -n product-catalog-api
 ```
 
 You can also verify that the container image in the deployment has been updated:
+
 ```
 kubectl describe deployment/product-catalog-api-staging -n product-catalog-api
 ```
 
 You can verify the creation of the DynamoDB table using the [DynamoDB console](https://console.aws.amazon.com/dynamodb/), or via the AWS CLI:
+
 ```
 aws dynamodb list-tables
 ```
 
 ### Detailed explanation of `update-cluster-app.sh` script
-
 
 The `update-cluster-app.sh` script makes a single change as follows. Please ensure your working directory is set to `~/envionment` before executing.
 
@@ -322,33 +338,51 @@ The `update-cluster-app.sh` script makes a single change as follows. Please ensu
 yq -i e ".spec.ref.tag = \"v2.0\"" gitops-workloads/commercial-staging/product-catalog-api/git-repo.yaml
 ```
 
-
 ## Upgrade an existing cluster
 
 In this section you will upgrade the cluster `commercial-staging` to a newer version
-of Kubernetes. To achieve this, you need to update the cluster configuration
-in `gitops-system/clusters-config/commercial-staging/def/eks-cluster.yaml`.
-Once done, you then push the changes so that flux can pick them up and act on them.
-
+of Kubernetes. As described in Amazon EKS documentaiton on ["Updating Kubernetes version"](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#update-existing-cluster), a cluster upgrade is a process of multiple steps. First you'll have to upgrade the Amazon EKS Cluster itslef, and after a successful completion of the cluster upgrade, you'll have to upgrade the nodes to the same Kubernetes version. In our sample, we are using [Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), so we will perform the upgrade of the node, by [updating](https://docs.aws.amazon.com/eks/latest/userguide/update-managed-node-group.html) the Managed Node Group that was created with the cluster.
 
 1. Open `gitops-system/clusters-config/commercial-staging/def/eks-cluster.yaml`.
 
-2. Change the value for `spec.parameters.k8s-version` (e.g. from `1.20` to `1.21`).
+2. Change the value for `spec.parameters.eks-k8s-version` (e.g. from `1.20` to `1.21`).
 
 3. Commit changes.
-```bash
-cd ~/environment/gitops-system/
-git add .
-git commit -m "upgrading commercial-staging cluster"
-git push
-```
+
+   ```bash
+   cd ~/environment/gitops-system/
+   git add .
+   git commit -m "upgrading commercial-staging cluster"
+   git push
+   ```
 
 4. Confirm that the cluster is updating using the following commands:
-```bash
-eksctl get cluster
-eksctl get cluster --name <cluster-name>
-```
-Alternatively, you can check the cluster status on the EKS console.
+
+   ```bash
+   eksctl get cluster
+   eksctl get cluster --name <cluster-name>
+   ```
+
+   Alternatively, you can check the cluster status on the EKS console.
+
+5. Change the `gitops-system/clusters-config/commercial-staging/def/eks-cluster.yaml` file again. This time change the value for `spec.parameters.mng-k8s-version` from 1.21 to 1.22.
+
+6. Commit again the changes.
+
+   ```bash
+   cd ~/environment/gitops-system/
+   git add .
+   git commit -m "updating managed node group version for commercial-staging cluster"
+   git push
+   ```
+
+7. Confirm that the cluster is updating using the following commands:
+
+   ```bash
+   eksctl get nodegroup --cluster <cluster-name> -o yaml
+   ```
+
+   Alternatively, you can check the managed node group status on the EKS console.
 
 ## Delete an application from a cluster
 
@@ -360,12 +394,14 @@ You also need to tidy up the `gitops-workloads/commercial-staging` directory by 
 the `product-catalog-api` directory.
 
 You can make the required changes quickly using the script `remove-cluster-app.sh`:
+
 ```
 cd ~/environment
 multi-cluster-gitops/bin/remove-cluster-app.sh ./gitops-workloads commercial-staging product-catalog-api
 ```
 
 Once done, commit and push the changes as follows:
+
 ```
 cd gitops-workloads
 git add .
@@ -373,7 +409,7 @@ git commit -m "Removed product-catalog-api from cluster commercial-staging"
 git push
 ```
 
-You can monitor the reconciliation of resources in the cluster using the 
+You can monitor the reconciliation of resources in the cluster using the
 method described previously.
 
 ### Detailed explanation of `remove-cluster-app.sh` script
@@ -381,17 +417,18 @@ method described previously.
 The `remove-cluster-app.sh` script performs the following steps. You can choose to execute these steps instead of running the script. Please ensure your working directory is set to `~/envionment` before executing.
 
 1. **Remove `product-catalog-api` from `gitops-workloads/commrical-staging/kustomization.yaml`:**
-this forces Flux to remove the application resources from the cluster.
+   this forces Flux to remove the application resources from the cluster.
+
 ```
 yq -i e "del ( .resources[] | select (. == \"product-catalog-api\" ))" gitops-workloads/commercial-staging/kustomization.yaml
 ```
 
 2. **Tidy up `gitops-workloads/commercial-staging`:** remove the application folder from the
-`gitops-workloads/commrical-staging` as it is no longer needed. 
+   `gitops-workloads/commrical-staging` as it is no longer needed.
+
 ```
 rm -rf gitops-workloads/commercial-staging/product-catalog-api
 ```
-
 
 ## Delete an existing cluster
 
@@ -404,12 +441,14 @@ Before proceeding, you should ensure that all applications running in the cluste
 have been removed.
 
 You can make the required repo changes quickly using the script `remove-cluster.sh`:
+
 ```
 cd ~/environment
 multi-cluster-gitops/bin/remove-cluster.sh ./gitops-system ./gitops-workloads commercial-staging
 ```
 
 Once done, commit and push the changes as follows:
+
 ```
 cd gitops-system
 git add .
@@ -421,7 +460,8 @@ git commit -m "Removed cluster commercial-staging"
 git push
 ```
 
-You can monitor the reconciliation of resources in the management cluster using 
+You can monitor the reconciliation of resources in the management cluster using
+
 ```
 kubectl get kustomization -n flux-system
 ```
@@ -431,7 +471,8 @@ kubectl get kustomization -n flux-system
 The `remove-cluster.sh` script performs the following steps. You can choose to execute these steps instead of running the script. Please ensure your working directory is set to `~/environment` before executing.
 
 1. **Remove `commercial-staging` from `gitops-system/clusters-config/kustomization.yaml`:**
-this forces Flux to remove the application resources from the cluster.
+   this forces Flux to remove the application resources from the cluster.
+
 ```
 yq -i e "del ( .resources[] | select (. == \"commercial-staging\" ))" gitops-system/clusters-config/kustomization.yaml
 ```


### PR DESCRIPTION
This commit introduce a change to the composition of the `EKSCluster` for separating  the upgrade process of the cluster into 2 parts. First, it will allow a Cluster upgrade only by setting a variable for the Amazon EKS cluster alone. Second, it allows to update the managed node group of the cluster, by setting a version for a separate variable, responsible for the data plane updates alone 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
