### PR TITLE
Update README.md

### DIFF
--- a/initial-setup/README.md
+++ b/initial-setup/README.md
@@ -109,7 +109,7 @@ Having set up your Cloud9 environment, you can now install a number of tools tha
 3. Install `kubeseal`
    ```bash
    wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.4/kubeseal-0.19.4-linux-amd64.tar.gz
-   tar xfz kubeseal-0.19.4-amd64.tar.gz
+   tar xfz kubeseal-0.19.4-linux-amd64.tar.gz
    sudo install -m 755 kubeseal /usr/local/bin/kubeseal
    ```
 

--- a/initial-setup/README.md
+++ b/initial-setup/README.md
@@ -108,8 +108,8 @@ Having set up your Cloud9 environment, you can now install a number of tools tha
 
 3. Install `kubeseal`
    ```bash
-   wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.0/kubeseal-0.19.0-darwin-amd64.tar.gz
-   tar xfz kubeseal-0.19.0-darwin-amd64.tar.gz
+   wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.4/kubeseal-0.19.4-linux-amd64.tar.gz
+   tar xfz kubeseal-0.19.4-amd64.tar.gz
    sudo install -m 755 kubeseal /usr/local/bin/kubeseal
    ```
 


### PR DESCRIPTION
*Issue #, if available:*
#65 

*Description of changes:*
Updated kubeseal installation to use latest linux version 0.19.4. Previously was using darwin version 0.19.0 (for Mac OSX) which was causing binary file exec format error on Cloud9 ubuntu.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
