### PR TITLE
Update initial setup README.md

### DIFF
--- a/initial-setup/README.md
+++ b/initial-setup/README.md
@@ -21,8 +21,9 @@ account you use for deploying this sample implementation can accommodate that.
     5. On the **Add Permissions** screen, choose **Create policy**. This action opens new tab in your browser for creating an IAM policy.
     6. In the new browser tab, choose **JSON**, paste the content of [cloud9-role-permission-policy-template.json](config/cloud9-role-permission-policy-template.json), replace `${ACCOUNT_ID}` (3 occurrences) with your AWS account id, replace `${AWS_REGION}` (2 occurrence) with the AWS region you are using, choose **Next**, then choose **Next** again. ![](img/iam-create-policy-json.png)
     7. Give the policy a name, for example "gitops-workshop", and choose **Create policy**. ![](img/iam-create-policy.png)
-    8. Return to the previous browser tab, click on the refresh button, add the IAM policy you created in the other browser tab, and choose **Next**.
-    9. Give the role a name, for example "gitops-workshop", and choose **Create role**. ![](img/iam-create-role.png)
+    8. Return to the previous browser tab, click on the refresh button, select the IAM policy you created in the other browser tab.
+    9. Use the policy filter to find the policy `AmazonSSMManagedInstanceCore` and select this too. Choose **Next**.
+    10. Give the role a name, for example "gitops-workshop", and choose **Create role**. ![](img/iam-create-role.png)
 
 4. Attach this IAM role to your Cloud9 EC2 instance as follows:
 


### PR DESCRIPTION
Updated to include the policy`AmazonSSMManagedInstanceCore` in the `gitops-workshop` role.

*Issue #, if available:*
#67 

*Description of changes:*
Updated role creation procedure to include the policy`AmazonSSMManagedInstanceCore` in the `gitops-workshop` role. This enables Cloud9 to connect to the EC2 instance via SSM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
